### PR TITLE
removed bug introduced by locale module

### DIFF
--- a/dash_tutorial/src/transformers.py
+++ b/dash_tutorial/src/transformers.py
@@ -1,5 +1,3 @@
-import locale
-
 import pandas as pd
 
 from src.schema import TransactionsSchema
@@ -31,7 +29,5 @@ def create_year_from_date(x: pd.DataFrame) -> pd.DataFrame:
 
 
 def create_month_from_date(x: pd.DataFrame) -> pd.DataFrame:
-    # I'm struggling with how to properly localize dates...
-    date_format = locale.nl_langinfo(locale.D_FMT)
     x[TransactionsSchema.month] = x[TransactionsSchema.date].dt.strftime("%m-%b")
     return x


### PR DESCRIPTION
According to the [Python Documentation](https://docs.python.org/3/library/locale.html#locale.nl_langinfo), the `locale.nl_langinfo` function "is not available on all systems, and the set of possible options might also vary across platforms," which introduced unexpected behavior. Removing this function allows the app to run again.

Could you please help me understand why this function was necessary? If it's critical, maybe we could find a way to include it, however, the data preprocessing pipeline assumes a specific date format (`"%m-%b"`). I guess we might want this to be configurable, but I think this small detail may take away from the main points of the video series.