### PR TITLE
handle app crash when dropdown selections return no data

### DIFF
--- a/dash_tutorial/locale/general.en.yml
+++ b/dash_tutorial/locale/general.en.yml
@@ -1,9 +1,11 @@
+---
 en:
-  hello_world: Hello, world!
+  amount: Amount
   app_title: Financial Dashboard
   category: Category
-  amount: Amount
-  year: Year
+  hello_world: Hello, world!
   month: Month
+  no_data: No data selected
   select: Select...
   select_all: Select all
+  year: Year

--- a/dash_tutorial/locale/general.nl.yml
+++ b/dash_tutorial/locale/general.nl.yml
@@ -1,9 +1,11 @@
+---
 nl:
-  hello_world: Hallo, wereld!
+  amount: Bedrag
   app_title: Financieel Dashboard
   category: Categorie
-  amount: Bedrag
-  year: Jaar
+  hello_world: Hallo, wereld!
   month: Maand
+  no_data: Geen gegevens geselecteerd
   select: Selecteer...
   select_all: Selecteer alles
+  year: Jaar

--- a/dash_tutorial/src/components/bar_chart.py
+++ b/dash_tutorial/src/components/bar_chart.py
@@ -13,7 +13,9 @@ def render(app: Dash) -> html.Div:
         Output(ids.BAR_CHART, "children"),
         Input(ids.RECORDS, "data"),
     )
-    def update_bar_chart(pivot_table_records: list[dict[str, float]]) -> dcc.Graph:
+    def update_bar_chart(pivot_table_records: list[dict[str, float]]) -> html.Div:
+        if len(pivot_table_records) == 0:
+            return html.Div(i18n.t("general.no_data"))
         pivot_table = pd.DataFrame(pivot_table_records).sort_values(
             DataSchema.AMOUNT.value, ascending=False
         )
@@ -28,6 +30,6 @@ def render(app: Dash) -> html.Div:
                 DataSchema.AMOUNT.value: i18n.t("general.amount"),
             },
         )
-        return dcc.Graph(figure=fig)
+        return html.Div(dcc.Graph(figure=fig))
 
     return html.Div(id=ids.BAR_CHART)

--- a/dash_tutorial/src/components/pie_chart.py
+++ b/dash_tutorial/src/components/pie_chart.py
@@ -1,3 +1,4 @@
+import i18n
 import pandas as pd
 import plotly.graph_objects as go
 from dash import Dash, dcc, html
@@ -12,7 +13,9 @@ def render(app: Dash) -> html.Div:
         Output(ids.PIE_CHART, "children"),
         Input(ids.RECORDS, "data"),
     )
-    def update_pie_chart(pivot_table_records: list[dict[str, float]]) -> dcc.Graph:
+    def update_pie_chart(pivot_table_records: list[dict[str, float]]) -> html.Div:
+        if len(pivot_table_records) == 0:
+            return html.Div(i18n.t("general.no_data"))
         pivot_table = pd.DataFrame(pivot_table_records)
         pie = go.Pie(
             labels=pivot_table.loc[:, DataSchema.CATEGORY.value],
@@ -22,6 +25,6 @@ def render(app: Dash) -> html.Div:
         fig = go.Figure(data=[pie])
         fig.update_layout(margin={"t": 40, "b": 0, "l": 0, "r": 0})
         fig.update_traces(hovertemplate="%{label}<br>$%{value:.2f}<extra></extra>")
-        return dcc.Graph(figure=fig)
+        return html.Div(dcc.Graph(figure=fig))
 
     return html.Div(id=ids.PIE_CHART)


### PR DESCRIPTION
## Issue

App crashed if selected dropdown combination failed to yield transaction data.

## Solution

Conditionally check if `pivot_table_records` are empty (`len == 0`) and return text using i18n instead of crashing app.

## Notes

I used Google Translate for the language conversion, so please forgive any errors on my part.