### PR TITLE
fix date format bug using babel

### DIFF
--- a/dash_tutorial/main.py
+++ b/dash_tutorial/main.py
@@ -18,7 +18,7 @@ def main() -> None:
     i18n.load_path.append("locale")
 
     # load the data and create the data manager
-    data = load_transaction_data(DATA_PATH)
+    data = load_transaction_data(DATA_PATH, LOCALE)
     data = DataSource(data)
 
     app = Dash(external_stylesheets=[BOOTSTRAP])

--- a/dash_tutorial/src/data/source.py
+++ b/dash_tutorial/src/data/source.py
@@ -50,11 +50,11 @@ class DataSource:
 
     @property
     def all_years(self) -> list[str]:
-        return self._data[DataSchema.DATE].dt.year.astype(str).tolist()
+        return self._data[DataSchema.YEAR].tolist()
 
     @property
     def all_months(self) -> list[str]:
-        return self._data[DataSchema.DATE].dt.month.astype(str).tolist()
+        return self._data[DataSchema.MONTH].tolist()
 
     @property
     def all_categories(self) -> list[str]:
@@ -70,7 +70,7 @@ class DataSource:
 
     @property
     def unique_months(self) -> list[str]:
-        return sorted(set(self.all_months), key=int)
+        return sorted(set(self.all_months))
 
     @property
     def unique_categories(self) -> list[str]:


### PR DESCRIPTION
- It appears that `babel` translates the language of the month given a locale, so we don't have to do this manually using `i18n`.
- The `convert_date_locale` function needs to know the locale, so I added this as an argument and pass a lambda closure to the preprocessing pipeline. You may know a better way to do this.
- I further simplified the `DataSource` properties to directly access the month and year columns of the dataframe. This is necessary to display the translated month names, and I think this it's a bit cleaner anyway.