### PR TITLE
Consistent config key for notes_directory

### DIFF
--- a/2024/python_cli/notes/crud.py
+++ b/2024/python_cli/notes/crud.py
@@ -89,7 +89,7 @@ def delete(ctx: click.Context, title: str):
 @click.pass_context
 def show(ctx: click.Context, tag: str, keyword: str):
     """Show notes."""
-    notes_dir: str = ctx.obj["notes_dir"]
+    notes_dir: str = ctx.obj["notes_directory"]
     notes = [note for note in os.listdir(notes_dir) if note.endswith(".txt")]
     results: list[str] = []
 


### PR DESCRIPTION
I was following along with your "How to Build a Complete Python Package Step-by-Step" tutorial from last year, and I encountered a KeyError when testing the `notes show` command.  I updated the key and retested, and after this small change, the command executes as expected, preventing the exception.   

I also want to thank you for sharing your knowledge through the content you post on YT - I have greatly enjoyed it since I first subscribed just shy of three years ago.  