### PR TITLE
Bug: Upgrade upload and download artifact actions to v4

### DIFF
--- a/2024/publish_pypi/release.yaml
+++ b/2024/publish_pypi/release.yaml
@@ -95,7 +95,7 @@ jobs:
           poetry build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -110,7 +110,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -131,7 +131,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## problem
currently it is failing because v3 is not allowed anymore.

## solution
changing to v4 fixes the problem. I tested it on a local project.
