### PR TITLE
ENV Path corrected

### DIFF
--- a/2025/project/Dockerfile
+++ b/2025/project/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 
 RUN uv sync
 
-ENV PATH="/app/.venv/bin:{$PATH}"
+ENV PATH="/app/.venv/bin:${PATH}"
 
 # Expose the specified port for FastAPI
 EXPOSE $PORT


### PR DESCRIPTION
$ is used at the wrong place while defining venv path:
correct path = "/app/.venv/bin:${PATH}"

Let me know if I'm mistaken.