### PR TITLE
[2026/spec]: improve type hints

### DIFF
--- a/2026/spec/main.py
+++ b/2026/spec/main.py
@@ -45,17 +45,17 @@ def has_override(u: User) -> bool:
 
 
 @rule
-def account_older_than(days: int, u: User) -> bool:
+def account_older_than(u: User, days: int) -> bool:
     return u.account_age > days
 
 
 @rule
-def from_country(countries: Iterable[str], u: User) -> bool:
+def from_country(u: User, countries: Iterable[str]) -> bool:
     return u.country in countries
 
 
 @rule
-def credit_score_above(threshold: int, u: User) -> bool:
+def credit_score_above(u: User, threshold: int) -> bool:
     return u.credit_score > threshold
 
 

--- a/2026/spec/rules.py
+++ b/2026/spec/rules.py
@@ -1,21 +1,23 @@
+from __future__ import annotations
+
 import json
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, Concatenate
 
 # ------------------------------------------------------------
 # Generic Types
 # ------------------------------------------------------------
 
 type PredicateFn[T] = Callable[[T], bool]
-type RuleDef = Callable[..., bool]
-type PredicateFactory[T] = Callable[..., Predicate[T]]
+type RuleDef[T, **P] = Callable[Concatenate[T, P], bool]
+type PredicateFactory[T, **P] = Callable[P, Predicate[T]]
 
 
 # ------------------------------------------------------------
 # Global Rule Registry
 # ------------------------------------------------------------
 
-RULES: dict[str, PredicateFactory[Any]] = {}
+RULES: dict[str, PredicateFactory[Any, ...]] = {}
 
 
 # ------------------------------------------------------------
@@ -59,10 +61,10 @@ def predicate[T](fn: PredicateFn[T]) -> Predicate[T]:
 
 
 
-def rule[T](fn: RuleDef) -> PredicateFactory[Any]:
+def rule[T, **P](fn: RuleDef[T, P]) -> PredicateFactory[T, P]:
     @wraps(fn)
-    def wrapper(*args: Any, **kwargs: Any) -> Predicate[T]:
-        return Predicate(lambda obj: fn(*args, obj, **kwargs))
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Predicate[T]:
+        return Predicate(lambda obj: fn(obj, *args, **kwargs))
 
     RULES[fn.__name__] = wrapper
     return wrapper


### PR DESCRIPTION
Inspired by this great [YouTube comment](https://www.youtube.com/watch?v=KqfMiuL3cx4&lc=UgxIBlwvNqAGSrHfVT94AaABAg) and its replies.

What changed
- used `from __future__ import annotations` because `Predicate` type hint is used inside `Predicate` class
- Improved typing around rule definitions and factories using `ParamSpec` and `Concatenate`
- Changed the order of parameters in the rule functions. Function parameter order was standardized to subject first, then extra parameters because `Concatenate` only supports prepending fixed parameters before `ParamSpec`, not appending after it.

Hope it can help other viewers :)